### PR TITLE
Remove math camp redirection

### DIFF
--- a/mikosite/mainSite/templates/header.html
+++ b/mikosite/mainSite/templates/header.html
@@ -27,7 +27,6 @@
     <ul class="navbar-center">
         <li><a href="/" {% if request.path == '/' %}id="current"{% endif %}>HOME</a></li>
         <li><a href="/kolo" {% if request.path == '/kolo/' %}id="current"{% endif %}>KOŁO MATEMATYCZNE</a></li>
-        <li><a href="https://oboz.inuni.org.pl/?utm_source=miko-website">OBÓZ</a></li>
         <li><a href="/about" {% if request.path == '/about/' %}id="current"{% endif %}>O NAS</a></li>
         <li><a href="#" {% if request.path == '/bazahintow/' %}id="current"{% endif %}>BAZA ZADAŃ</a></li>
         <li class="profile-item"><a href="#" {% if request.path == '/profile/' %}id="current"{% endif %}>PROFIL</a></li>


### PR DESCRIPTION
Commit b084e86568fa916d67b918a1ac2893777056884f modified the website header to advertize the summer camp by MIKO.

Since registration for the camp has already concluded, there is no reason to keep the redirection.