### PR TITLE
Hide problemset until end of development

### DIFF
--- a/mikosite/mikosite/urls.py
+++ b/mikosite/mikosite/urls.py
@@ -41,7 +41,7 @@ urlpatterns = [
     path("", include("mainSite.urls")),
     path('', include('accounts.urls')),
     path('kolo/', include('seminars.urls')),
-    path("bazahintow/", include("hintBase.urls")),
+    # path("bazahintow/", include("hintBase.urls")),
     path('api/', include(router.urls)),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 


### PR DESCRIPTION
Currently the website publicly exposes the problemset (hintbase), which is still under development and in its staging phase.

This commit hides the endpoints related th the problemset. This change should stay in effect until the problemset is ready for release.