### PR TITLE
Add POZDRO 2026 redirection

### DIFF
--- a/mikosite/mainSite/templates/header.html
+++ b/mikosite/mainSite/templates/header.html
@@ -28,7 +28,7 @@
         <li><a href="/" {% if request.path == '/' %}id="current"{% endif %}>HOME</a></li>
         <li><a href="/kolo" {% if request.path == '/kolo/' %}id="current"{% endif %}>KOŁO MATEMATYCZNE</a></li>
         <li><a href="/about" {% if request.path == '/about/' %}id="current"{% endif %}>O NAS</a></li>
-        <li><a href="#" {% if request.path == '/bazahintow/' %}id="current"{% endif %}>BAZA ZADAŃ</a></li>
+        <li><a href="/pozdro/" id="highlighted">POZDRO 2026</a></li>
         <li class="profile-item"><a href="#" {% if request.path == '/profile/' %}id="current"{% endif %}>PROFIL</a></li>
     </ul>
     <div class="navbar-right">

--- a/mikosite/static/mainSite/headerStyle.css
+++ b/mikosite/static/mainSite/headerStyle.css
@@ -40,6 +40,15 @@
 #current:hover {
   color: var(--y1);
 }
+#highlighted {
+  color: #fff;
+  background-color: var(--b1);
+  border-radius: 3px;
+  padding: 2px 5px;
+}
+#highlighted:hover {
+  background-color: var(--y1);
+}
 
 .navbar-right{
   display: block;


### PR DESCRIPTION
A redirect link to POZDRO 2026 contest website was added to the navbar to promote the contest. Additionally, header stylesheet was modified to allow for highlighted items, which are displayed more prominently.

This redirection replaced the empty link to the problem set, which is not ready yet.