### PR TITLE
Add SprawdzAI link to header

### DIFF
--- a/mikosite/mainSite/templates/header.html
+++ b/mikosite/mainSite/templates/header.html
@@ -30,7 +30,8 @@
             <li><a href="/" {% if request.path == '/' %}id="current"{% endif %}>HOME</a></li>
             <li><a href="/kolo" {% if request.path == '/kolo/' %}id="current"{% endif %}>KOŁO MATEMATYCZNE</a></li>
             <li><a href="/about" {% if request.path == '/about/' %}id="current"{% endif %}>O NAS</a></li>
-            <li><a href="/pozdro/" id="highlighted">POZDRO 2026</a></li>
+            <li><a href="https://sprawdzai.org/?utm_source=mikomath.org&utm_medium=referral&utm_campaign=sprawdzai&utm_content=header
+" id="highlighted">SPRAWDZAI</a></li>
             <li class="profile-item">
                 {% if user.is_authenticated %}
                     <a href="/profile/" {% if request.path == '/profile/' %}id="current"{% endif %}>PROFIL</a>


### PR DESCRIPTION
This pull request removes the outdated POZDRO competition link from the navbar after the 2026 edition concluded in January.

In its place, we introduce a highlighted navbar tab that links to SprawdzAI, our in-house AI/ML online judge, as part of a larger marketing campaign.